### PR TITLE
Add provider and school partnerships in support

### DIFF
--- a/app/controllers/support/organisations/partner-providers.js
+++ b/app/controllers/support/organisations/partner-providers.js
@@ -1,0 +1,218 @@
+const organisationModel = require('../../../models/organisations')
+const organisationRelationshipModel = require('../../../models/organisation-relationships')
+const providerModel = require('../../../models/providers')
+
+const Pagination = require('../../../helpers/pagination')
+
+/// ------------------------------------------------------------------------ ///
+/// LIST PARTNER PROVIDERS
+/// ------------------------------------------------------------------------ ///
+
+exports.partner_providers_list = (req, res) => {
+  const organisation = organisationModel.findOne({ organisationId: req.params.organisationId })
+  let partners = []
+
+  if (organisation.relationships) {
+    organisation.relationships.forEach(id => {
+      const provider = providerModel.findOne({ query: id })
+      partners.push(provider)
+    })
+
+    partners.sort((a, b) => {
+      return a.name.localeCompare(b.name)
+    })
+  }
+
+  // TODO: get pageSize from settings
+  let pageSize = 25
+  let pagination = new Pagination(partners, req.query.page, pageSize)
+  partners = pagination.getData()
+console.log(partners);
+  delete req.session.data.provider
+
+  res.render('../views/support/organisations/partners/providers/list', {
+    organisation,
+    partners,
+    pagination,
+    actions: {
+      new: `/support/organisations/${req.params.organisationId}/providers/new`,
+      view: `/support/organisations/${req.params.organisationId}/providers`
+    }
+  })
+}
+
+/// ------------------------------------------------------------------------ ///
+/// SHOW PARTNER PROVIDER
+/// ------------------------------------------------------------------------ ///
+
+exports.partner_provider_details = (req, res) => {
+  const organisation = organisationModel.findOne({ organisationId: req.params.organisationId })
+  const provider = providerModel.findOne({ query: req.params.providerId })
+
+  res.render('../views/support/organisations/partners/providers/show', {
+    organisation,
+    provider,
+    actions: {
+      change: `/support/organisations/${req.params.organisationId}/providers/${req.params.providerId}`,
+      delete: `/support/organisations/${req.params.organisationId}/providers/${req.params.providerId}/delete`,
+      back: `/support/organisations/${req.params.organisationId}/providers`,
+      cancel: `/support/organisations/${req.params.organisationId}/providers`
+    }
+  })
+}
+
+/// ------------------------------------------------------------------------ ///
+/// ADD PARTNER PROVIDER
+/// ------------------------------------------------------------------------ ///
+
+exports.new_partner_provider_get = (req, res) => {
+  const organisation = organisationModel.findOne({ organisationId: req.params.organisationId })
+
+  let save = `/support/organisations/${req.params.organisationId}/providers/new`
+  let back = `/support/organisations/${req.params.organisationId}/providers`
+
+  if (req.query.referrer === 'check') {
+    save += '?referrer=check'
+    back = `/support/organisations/${req.params.organisationId}/providers/new/check`
+  }
+
+  res.render('../views/support/organisations/partners/providers/find', {
+    organisation,
+    actions: {
+      save,
+      back,
+      cancel: `/support/organisations/${req.params.organisationId}/providers`
+    }
+  })
+}
+
+exports.new_partner_provider_post = (req, res) => {
+  const organisation = organisationModel.findOne({ organisationId: req.params.organisationId })
+
+  let save = `/support/organisations/${req.params.organisationId}/providers/new`
+  let back = `/support/organisations/${req.params.organisationId}/providers`
+
+  if (req.query.referrer === 'check') {
+    save += '?referrer=check'
+    back = `/support/organisations/${req.params.organisationId}/providers/new/check`
+  }
+
+  const errors = []
+
+  if (!req.session.data.provider.name.length) {
+    const error = {}
+    error.fieldName = 'provider'
+    error.href = '#provider'
+    error.text = 'Enter a provider name, UKPRN, URN or postcode'
+    errors.push(error)
+
+    res.render('../views/support/organisations/partners/providers/find', {
+      organisation,
+      actions: {
+        save,
+        back,
+        cancel: `/support/organisations/${req.params.organisationId}/providers`
+      },
+      errors
+    })
+  } else {
+    // const schools = schoolModel.findMany({
+    //   query: req.session.data.provider.name
+    // })
+
+    // if (schools.length > 1) {
+    //   res.redirect(`/support/organisations/${req.params.organisationId}/providers/choose`)
+    // } else {
+      const provider = providerModel.findOne({ query: req.session.data.provider.name })
+
+      let relationship = false
+
+      if (organisation.relationships) {
+        relationship = !!organisation.relationships.find(relationship => relationship.includes(provider.id))
+      }
+
+      if (relationship) {
+        const error = {}
+        error.fieldName = 'provider'
+        error.href = '#provider'
+        error.text = 'Partner provider has already been added'
+        errors.push(error)
+      }
+
+      if (errors.length) {
+        res.render('../views/support/organisations/partners/providers/find', {
+          organisation,
+          actions: {
+            save,
+            back,
+            cancel: `/support/organisations/${req.params.organisationId}/providers`
+          },
+          errors
+        })
+      } else {
+        const provider = providerModel.findOne({ query: req.session.data.provider.name })
+
+        req.session.data.provider.id = provider.id
+
+        res.redirect(`/support/organisations/${req.params.organisationId}/providers/new/check`)
+      }
+    // }
+  }
+}
+
+exports.new_partner_provider_check_get = (req, res) => {
+  const organisation = organisationModel.findOne({ organisationId: req.params.organisationId })
+  const provider = providerModel.findOne({ query: req.session.data.provider.id })
+console.log(provider);
+  res.render('../views/support/organisations/partners/providers/check-your-answers', {
+    organisation,
+    provider,
+    actions: {
+      save: `/support/organisations/${req.params.organisationId}/providers/new/check`,
+      back: `/support/organisations/${req.params.organisationId}/providers/new`,
+      cancel: `/support/organisations/${req.params.organisationId}/providers`,
+      change: `/support/organisations/${req.params.organisationId}/providers/new`
+    }
+  })
+}
+
+exports.new_partner_provider_check_post = (req, res) => {
+  organisationRelationshipModel.saveOne({
+    providerId: req.session.data.provider.id,
+    schoolId: req.params.organisationId
+  })
+
+  delete req.session.data.provider
+
+  req.flash('success', 'Partner provider added')
+  res.redirect(`/support/organisations/${req.params.organisationId}/providers`)
+}
+
+/// ------------------------------------------------------------------------ ///
+/// DELETE PARTNER PROVIDER
+/// ------------------------------------------------------------------------ ///
+
+exports.delete_partner_provider_get = (req, res) => {
+  const organisation = organisationModel.findOne({ organisationId: req.params.organisationId })
+  const provider = providerModel.findOne({ query: req.params.providerId })
+
+  res.render('../views/support/organisations/partners/providers/delete', {
+    organisation,
+    provider,
+    actions: {
+      save: `/support/organisations/${req.params.organisationId}/providers/${req.params.providerId}/delete`,
+      back: `/support/organisations/${req.params.organisationId}/providers/${req.params.providerId}`,
+      cancel: `/support/organisations/${req.params.organisationId}/providers/${req.params.providerId}`
+    }
+  })
+}
+
+exports.delete_partner_provider_post = (req, res) => {
+  organisationRelationshipModel.deleteOne({
+    providerId: req.params.providerId,
+    schoolId: req.params.organisationId
+  })
+
+  req.flash('success', 'Partner school removed')
+  res.redirect(`/support/organisations/${req.params.organisationId}/providers`)
+}

--- a/app/controllers/support/organisations/partner-schools.js
+++ b/app/controllers/support/organisations/partner-schools.js
@@ -1,0 +1,213 @@
+const partnerSchoolModel = require('../../../models/partner-schools')
+const organisationModel = require('../../../models/organisations')
+const organisationRelationshipModel = require('../../../models/organisation-relationships')
+const schoolModel = require('../../../models/schools')
+
+const Pagination = require('../../../helpers/pagination')
+
+/// ------------------------------------------------------------------------ ///
+/// LIST PARTNER SCHOOLS
+/// ------------------------------------------------------------------------ ///
+
+exports.partner_schools_list = (req, res) => {
+  const organisation = organisationModel.findOne({ organisationId: req.params.organisationId })
+  let partners = partnerSchoolModel.findMany({ organisationId: req.params.organisationId })
+
+  partners.sort((a, b) => {
+    return a.name.localeCompare(b.name)
+  })
+
+  // TODO: get pageSize from settings
+  let pageSize = 25
+  let pagination = new Pagination(partners, req.query.page, pageSize)
+  partners = pagination.getData()
+
+  delete req.session.data.school
+
+  res.render('../views/support/organisations/partners/schools/list', {
+    organisation,
+    partners,
+    pagination,
+    actions: {
+      new: `/support/organisations/${req.params.organisationId}/schools/new`,
+      view: `/support/organisations/${req.params.organisationId}/schools`
+    }
+  })
+}
+
+/// ------------------------------------------------------------------------ ///
+/// SHOW PARTNER SCHOOL
+/// ------------------------------------------------------------------------ ///
+
+exports.partner_school_details = (req, res) => {
+  const organisation = organisationModel.findOne({ organisationId: req.params.organisationId })
+  const school = organisationModel.findOne({ organisationId: req.params.schoolId })
+
+  res.render('../views/support/organisations/partners/schools/show', {
+    organisation,
+    school,
+    actions: {
+      change: `/support/organisations/${req.params.organisationId}/schools/${req.params.schoolId}`,
+      delete: `/support/organisations/${req.params.organisationId}/schools/${req.params.schoolId}/delete`,
+      back: `/support/organisations/${req.params.organisationId}/schools`,
+      cancel: `/support/organisations/${req.params.organisationId}/schools`
+    }
+  })
+}
+
+/// ------------------------------------------------------------------------ ///
+/// ADD PARTNER SCHOOL
+/// ------------------------------------------------------------------------ ///
+
+exports.new_partner_school_get = (req, res) => {
+  const organisation = organisationModel.findOne({ organisationId: req.params.organisationId })
+
+  let save = `/support/organisations/${req.params.organisationId}/schools/new`
+  let back = `/support/organisations/${req.params.organisationId}/schools`
+
+  if (req.query.referrer === 'check') {
+    save += '?referrer=check'
+    back = `/support/organisations/${req.params.organisationId}/schools/new/check`
+  }
+
+  res.render('../views/support/organisations/partners/schools/find', {
+    organisation,
+    actions: {
+      save,
+      back,
+      cancel: `/support/organisations/${req.params.organisationId}/schools`
+    }
+  })
+}
+
+exports.new_partner_school_post = (req, res) => {
+  const organisation = organisationModel.findOne({ organisationId: req.params.organisationId })
+
+  let save = `/support/organisations/${req.params.organisationId}/schools/new`
+  let back = `/support/organisations/${req.params.organisationId}/schools`
+
+  if (req.query.referrer === 'check') {
+    save += '?referrer=check'
+    back = `/support/organisations/${req.params.organisationId}/schools/new/check`
+  }
+
+  const errors = []
+
+  if (!req.session.data.school.name.length) {
+    const error = {}
+    error.fieldName = 'school'
+    error.href = '#school'
+    error.text = 'Enter a school name, URN or postcode'
+    errors.push(error)
+
+    res.render('../views/support/organisations/partners/schools/find', {
+      organisation,
+      actions: {
+        save,
+        back,
+        cancel: `/support/organisations/${req.params.organisationId}/schools`
+      },
+      errors
+    })
+  } else {
+    // const schools = schoolModel.findMany({
+    //   query: req.session.data.school.name
+    // })
+
+    // if (schools.length > 1) {
+    //   res.redirect(`/support/organisations/${req.params.organisationId}/schools/choose`)
+    // } else {
+      const school = schoolModel.findOne({ query: req.session.data.school.name })
+      const schoolOrg = organisationModel.findOne({ organisationId: school.id })
+
+      let relationship = false
+
+      if (schoolOrg.relationships) {
+        relationship = !!schoolOrg.relationships.find(relationship => relationship.includes(req.params.organisationId))
+      }
+
+      if (relationship) {
+        const error = {}
+        error.fieldName = 'school'
+        error.href = '#school'
+        error.text = 'Partner school has already been added'
+        errors.push(error)
+      }
+
+      if (errors.length) {
+        res.render('../views/support/organisations/partners/schools/find', {
+          organisation,
+          actions: {
+            save,
+            back,
+            cancel: `/support/organisations/${req.params.organisationId}/schools`
+          },
+          errors
+        })
+      } else {
+        const school = schoolModel.findOne({ query: req.session.data.school.name })
+
+        req.session.data.school.id = school.id
+
+        res.redirect(`/support/organisations/${req.params.organisationId}/schools/new/check`)
+      }
+    // }
+  }
+}
+
+exports.new_partner_school_check_get = (req, res) => {
+  const organisation = organisationModel.findOne({ organisationId: req.params.organisationId })
+  const school = schoolModel.findOne({ query: req.session.data.school.id })
+
+  res.render('../views/support/organisations/partners/schools/check-your-answers', {
+    organisation,
+    school,
+    actions: {
+      save: `/support/organisations/${req.params.organisationId}/schools/new/check`,
+      back: `/support/organisations/${req.params.organisationId}/schools/new`,
+      cancel: `/support/organisations/${req.params.organisationId}/schools`,
+      change: `/support/organisations/${req.params.organisationId}/schools/new`
+    }
+  })
+}
+
+exports.new_partner_school_check_post = (req, res) => {
+  organisationRelationshipModel.saveOne({
+    providerId: req.params.organisationId,
+    schoolId: req.session.data.school.id
+  })
+
+  delete req.session.data.school
+
+  req.flash('success', 'Partner school added')
+  res.redirect(`/support/organisations/${req.params.organisationId}/schools`)
+}
+
+/// ------------------------------------------------------------------------ ///
+/// DELETE PARTNER SCHOOL
+/// ------------------------------------------------------------------------ ///
+
+exports.delete_partner_school_get = (req, res) => {
+  const organisation = organisationModel.findOne({ organisationId: req.params.organisationId })
+  const school = organisationModel.findOne({ organisationId: req.params.schoolId })
+
+  res.render('../views/support/organisations/partners/schools/delete', {
+    organisation,
+    school,
+    actions: {
+      save: `/support/organisations/${req.params.organisationId}/schools/${req.params.schoolId}/delete`,
+      back: `/support/organisations/${req.params.organisationId}/schools/${req.params.schoolId}`,
+      cancel: `/support/organisations/${req.params.organisationId}/schools/${req.params.schoolId}`
+    }
+  })
+}
+
+exports.delete_partner_school_post = (req, res) => {
+  organisationRelationshipModel.deleteOne({
+    providerId: req.params.organisationId,
+    schoolId: req.params.schoolId
+  })
+
+  req.flash('success', 'Partner school removed')
+  res.redirect(`/support/organisations/${req.params.organisationId}/schools`)
+}

--- a/app/routes.js
+++ b/app/routes.js
@@ -50,18 +50,20 @@ const accountController = require('./controllers/account')
 const authenticationController = require('./controllers/authentication')
 const contentController = require('./controllers/content')
 const feedbackController = require('./controllers/feedback')
+const findPlacementController = require('./controllers/find-placements')
 const mentorController = require('./controllers/mentors')
 const organisationController = require('./controllers/organisations')
-const userController = require('./controllers/users')
-const placementController = require('./controllers/placements')
-const partnerSchoolController = require('./controllers/partner-schools')
 const partnerProviderController = require('./controllers/partner-providers')
-const findPlacementController = require('./controllers/find-placements')
+const partnerSchoolController = require('./controllers/partner-schools')
+const placementController = require('./controllers/placements')
+const userController = require('./controllers/users')
 
 const supportOrganisationController = require('./controllers/support/organisations')
 const supportOrganisationMentorController = require('./controllers/support/organisations/mentors')
 const supportOrganisationPlacementController = require('./controllers/support/organisations/placements')
 const supportOrganisationUserController = require('./controllers/support/organisations/users')
+const supportOrganisationPartnerProviderController = require('./controllers/support/organisations/partner-providers')
+const supportOrganisationPartnerSchoolController = require('./controllers/support/organisations/partner-schools')
 const supportUserController = require('./controllers/support/users')
 
 // Authentication middleware
@@ -353,6 +355,40 @@ router.post('/support/organisations/:organisationId/mentors/:mentorId/delete', c
 router.get('/support/organisations/:organisationId/mentors/:mentorId', checkIsAuthenticated, supportOrganisationMentorController.mentor_details)
 
 router.get('/support/organisations/:organisationId/mentors', checkIsAuthenticated, supportOrganisationMentorController.mentor_list)
+
+/// ------------------------------------------------------------------------ ///
+/// SUPPORT - ORGANISATION PARTNER SCHOOL ROUTES
+/// ------------------------------------------------------------------------ ///
+
+router.get('/support/organisations/:organisationId/schools/new', checkIsAuthenticated, supportOrganisationPartnerSchoolController.new_partner_school_get)
+router.post('/support/organisations/:organisationId/schools/new', checkIsAuthenticated, supportOrganisationPartnerSchoolController.new_partner_school_post)
+
+router.get('/support/organisations/:organisationId/schools/new/check', checkIsAuthenticated, supportOrganisationPartnerSchoolController.new_partner_school_check_get)
+router.post('/support/organisations/:organisationId/schools/new/check', checkIsAuthenticated, supportOrganisationPartnerSchoolController.new_partner_school_check_post)
+
+router.get('/support/organisations/:organisationId/schools/:schoolId/delete', checkIsAuthenticated, supportOrganisationPartnerSchoolController.delete_partner_school_get)
+router.post('/support/organisations/:organisationId/schools/:schoolId/delete', checkIsAuthenticated, supportOrganisationPartnerSchoolController.delete_partner_school_post)
+
+router.get('/support/organisations/:organisationId/schools/:schoolId', checkIsAuthenticated, supportOrganisationPartnerSchoolController.partner_school_details)
+
+router.get('/support/organisations/:organisationId/schools', checkIsAuthenticated, supportOrganisationPartnerSchoolController.partner_schools_list)
+
+/// ------------------------------------------------------------------------ ///
+/// SUPPORT - ORGANISATION PARTNER PROVIDER ROUTES
+/// ------------------------------------------------------------------------ ///
+
+router.get('/support/organisations/:organisationId/providers/new', checkIsAuthenticated, supportOrganisationPartnerProviderController.new_partner_provider_get)
+router.post('/support/organisations/:organisationId/providers/new', checkIsAuthenticated, supportOrganisationPartnerProviderController.new_partner_provider_post)
+
+router.get('/support/organisations/:organisationId/providers/new/check', checkIsAuthenticated, supportOrganisationPartnerProviderController.new_partner_provider_check_get)
+router.post('/support/organisations/:organisationId/providers/new/check', checkIsAuthenticated, supportOrganisationPartnerProviderController.new_partner_provider_check_post)
+
+router.get('/support/organisations/:organisationId/providers/:providerId/delete', checkIsAuthenticated, supportOrganisationPartnerProviderController.delete_partner_provider_get)
+router.post('/support/organisations/:organisationId/providers/:providerId/delete', checkIsAuthenticated, supportOrganisationPartnerProviderController.delete_partner_provider_post)
+
+router.get('/support/organisations/:organisationId/providers/:providerId', checkIsAuthenticated, supportOrganisationPartnerProviderController.partner_provider_details)
+
+router.get('/support/organisations/:organisationId/providers', checkIsAuthenticated, supportOrganisationPartnerProviderController.partner_providers_list)
 
 /// ------------------------------------------------------------------------ ///
 /// SUPPORT - ORGANISATION PLACEMENT ROUTES

--- a/app/views/support/organisations/_secondary-navigation.njk
+++ b/app/views/support/organisations/_secondary-navigation.njk
@@ -12,6 +12,16 @@
       active: secondaryNavId == "users"
     },
     {
+      href: baseUrl + "/providers",
+      text: "Partner providers",
+      active: secondaryNavId == "providers"
+    } if organisation.type == "school",
+    {
+      href: baseUrl + "/schools",
+      text: "Partner schools",
+      active: secondaryNavId == "schools"
+    } if organisation.type != "school",
+    {
       href: baseUrl + "/mentors",
       text: "Mentors",
       active: secondaryNavId == "mentors"
@@ -25,16 +35,6 @@
       href: "#",
       text: "Trainees",
       active: secondaryNavId == "trainees"
-    } if organisation.type != "school" and 1==0,
-    {
-      href: "#",
-      text: "Providers",
-      active: secondaryNavId == "providers"
-    } if organisation.type == "school" and 1==0,
-    {
-      href: "#",
-      text: "Schools",
-      active: secondaryNavId == "schools"
     } if organisation.type != "school" and 1==0
   ]
 }) }}

--- a/app/views/support/organisations/partners/providers/check-your-answers.njk
+++ b/app/views/support/organisations/partners/providers/check-your-answers.njk
@@ -1,0 +1,109 @@
+{% extends "layouts/support.njk" %}
+
+{% set primaryNavId = "organisations" %}
+
+{% set title = "Check your answers" %}
+{% set caption = "Add partner provider - " + organisation.name %}
+
+{% block beforeContent %}
+{{ govukBackLink({
+  text: "Back",
+  href: actions.back
+}) }}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      {% include "_includes/page-heading.njk" %}
+
+      <form action="{{ actions.save }}" method="post" accept-charset="utf-8" novalidate>
+
+        {% set addressHtml %}
+          {% if provider.address.addressLine1.length
+            and provider.address.town.length
+            and provider.address.postcode.length %}
+            <p class="govuk-body">
+              {% if provider.address.addressLine1.length %}
+                {{ provider.address.addressLine1 }}<br>
+              {% endif %}
+              {% if provider.address.addressLine2.length %}
+                {{ provider.address.addressLine2 }}<br>
+              {% endif %}
+              {% if provider.address.town.length %}
+                {{ provider.address.town }}<br>
+              {% endif %}
+              {% if provider.address.county.length %}
+                {{ provider.address.county }}<br>
+              {% endif %}
+              {% if provider.address.postcode.length %}
+                {{ provider.address.postcode | upper }}<br>
+              {% endif %}
+            </p>
+          {% else %}
+            <p class="govuk-hint">Not entered</p>
+          {% endif %}
+
+        {% endset %}
+
+        {{ govukSummaryList({
+          rows: [
+            {
+              key: {
+                text: "Organisation name"
+              },
+              value: {
+                text: provider.name if provider.name else "Not entered",
+                classes: "govuk-hint" if not provider.name
+              },
+              actions: {
+                items: [
+                  {
+                    href: actions.change + "/" + "?referrer=check",
+                    text: "Change",
+                    visuallyHiddenText: "name"
+                  }
+                ]
+              }
+            },
+            {
+              key: {
+                text: "UK provider reference number (UKPRN)"
+              },
+              value: {
+                text: provider.ukprn if provider.ukprn else "Not entered",
+                classes: "govuk-hint" if not provider.ukprn
+              }
+            },
+            {
+              key: {
+                text: "Unique reference number (URN)"
+              },
+              value: {
+                text: provider.urn if provider.urn else "Not entered",
+                classes: "govuk-hint" if not provider.urn
+              }
+            }
+          ]
+        }) }}
+
+        {% set organisation = provider %}
+
+        {% include "_includes/organisations/contact-details.njk" %}
+
+        {{ govukButton({
+          text: "Add partner provider"
+        }) }}
+
+      </form>
+
+      <p class="govuk-body">
+        <a class="govuk-link" href="{{ actions.cancel }}">Cancel</a>
+      </p>
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/support/organisations/partners/providers/delete.njk
+++ b/app/views/support/organisations/partners/providers/delete.njk
@@ -1,0 +1,44 @@
+{% extends "layouts/support.njk" %}
+
+{% set primaryNavId = "organisations" %}
+
+{% set title = "Are you sure you want to remove this partner provider?" %}
+{% set caption = provider.name + " - " + organisation.name %}
+
+{% block pageTitle %}
+  {{ "Error: " if errors.length }}{{ title + " - " if title }}{{ caption + " - " if caption }}{{ serviceName }} - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+{{ govukBackLink({
+  text: "Back",
+  href: actions.back
+}) }}
+{% endblock %}
+
+{% block content %}
+
+  {% include "_includes/error-summary.njk" %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      {% include "_includes/page-heading.njk" %}
+
+      <form action="{{ actions.save }}" method="post" accept-charset="utf-8" novalidate>
+
+        {{ govukButton({
+          text: "Remove partner provider",
+          classes: "govuk-button--warning"
+        }) }}
+
+      </form>
+
+      <p class="govuk-body">
+        <a class="govuk-link" href="{{ actions.cancel }}">Cancel</a>
+      </p>
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/support/organisations/partners/providers/find.njk
+++ b/app/views/support/organisations/partners/providers/find.njk
@@ -1,0 +1,75 @@
+{% extends "layouts/support.njk" %}
+
+{% set primaryNavId = "organisations" %}
+
+{% set title = "Enter a provider name, UKPRN, URN or postcode" %}
+{% set caption = "Add partner provider - " + organisation.name %}
+
+{% block beforeContent %}
+{{ govukBackLink({
+  text: "Back",
+  href: actions.back
+}) }}
+{% endblock %}
+
+{% block content %}
+
+  {% include "_includes/error-summary.njk" %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      {% set headingHtml %}
+        {% include "_includes/page-heading-legend.njk" %}
+      {% endset %}
+
+      <form action="{{ actions.save }}" method="post" accept-charset="utf-8" novalidate>
+
+        <div class="govuk-form-group {{- ' govuk-form-group--error' if (errors | getErrorMessage('provider'))}}">
+          {{ govukInput({
+            id: "provider",
+            name: "provider[name]",
+            label: {
+              html: headingHtml,
+              isPageHeading: true,
+              classes: "govuk-label--l"
+            },
+            value: data.provider.name,
+            autocomplete: "off",
+            formGroup: {
+              classes: "govuk-!-margin-bottom-0"
+            },
+            errorMessage: errors | getErrorMessage("provider")
+          }) }}
+          <div id="provider-autocomplete" class="govuk-body"></div>
+        </div>
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+
+      <p class="govuk-body">
+        <a class="govuk-link" href="{{ actions.cancel }}">Cancel</a>
+      </p>
+
+    </div>
+  </div>
+
+{% endblock %}
+
+{% block pageScripts %}
+  <script src="/public/javascripts/accessible-autocomplete.min.js"></script>
+  <script src="/public/javascripts/debounce.js"></script>
+  <script src="/public/javascripts/init-autocomplete.js"></script>
+
+  <script type="text/javascript">
+  initAutocomplete({
+    element: "provider-autocomplete",
+    input: "provider",
+    path: "/provider-suggestions",
+    type: "provider"
+  });
+  </script>
+{% endblock %}

--- a/app/views/support/organisations/partners/providers/list.njk
+++ b/app/views/support/organisations/partners/providers/list.njk
@@ -1,0 +1,48 @@
+{% extends "layouts/support.njk" %}
+
+{% set primaryNavId = "organisations" %}
+{% set secondaryNavId = "providers" %}
+
+{% set title = organisation.name %}
+
+{% block beforeContent %}
+
+{% endblock %}
+
+{% block content %}
+
+  {% include "_includes/notification-banner.njk" %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% include "_includes/page-heading.njk" %}
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      {% include "../../_secondary-navigation.njk" %}
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h2 class="govuk-heading-m">Partner providers</h2>
+
+      {{ govukButton({
+        text: "Add partner provider",
+        href: actions.new
+      }) }}
+
+      {% if partners.length %}
+        {% include "_includes/partners/providers/list.njk" %}
+        {% include "_includes/pagination.njk" %}
+      {% else %}
+        <p class="govuk-body">There are no {{ title | lower }} for {{ organisation.name if organisation.name else "your organisation" }}.</p>
+      {% endif %}
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/support/organisations/partners/providers/show.njk
+++ b/app/views/support/organisations/partners/providers/show.njk
@@ -1,0 +1,37 @@
+{% extends "layouts/support.njk" %}
+
+{% set primaryNavId = "organisations" %}
+
+{% set title = provider.name %}
+{% set caption = "Partner providers - " + organisation.name %}
+
+{% block beforeContent %}
+{{ govukBackLink({
+  text: "Back",
+  href: actions.back
+}) }}
+{% endblock %}
+
+{% block content %}
+
+  {% include "_includes/notification-banner.njk" %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      {% include "_includes/page-heading.njk" %}
+
+      {% set organisation = provider %}
+
+      {% include "_includes/organisations/details.njk" %}
+
+      {% include "_includes/organisations/contact-details.njk" %}
+
+      <p class="govuk-body">
+        <a class="govuk-link app-link--destructive" href="{{ actions.delete }}">Remove partner provider</a>
+      </p>
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/support/organisations/partners/schools/check-your-answers.njk
+++ b/app/views/support/organisations/partners/schools/check-your-answers.njk
@@ -1,0 +1,115 @@
+{% extends "layouts/support.njk" %}
+
+{% set primaryNavId = "organisations" %}
+
+{% set title = "Check your answers" %}
+{% set caption = "Add partner school - " + organisation.name %}
+
+{% block beforeContent %}
+{{ govukBackLink({
+  text: "Back",
+  href: actions.back
+}) }}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      {% include "_includes/page-heading.njk" %}
+
+      <form action="{{ actions.save }}" method="post" accept-charset="utf-8" novalidate>
+
+        {% set addressHtml %}
+          {% if school.address.addressLine1.length
+            and school.address.town.length
+            and school.address.postcode.length %}
+            <p class="govuk-body">
+              {% if school.address.addressLine1.length %}
+                {{ school.address.addressLine1 }}<br>
+              {% endif %}
+              {% if school.address.addressLine2.length %}
+                {{ school.address.addressLine2 }}<br>
+              {% endif %}
+              {% if school.address.town.length %}
+                {{ school.address.town }}<br>
+              {% endif %}
+              {% if school.address.county.length %}
+                {{ school.address.county }}<br>
+              {% endif %}
+              {% if school.address.postcode.length %}
+                {{ school.address.postcode | upper }}<br>
+              {% endif %}
+            </p>
+          {% else %}
+            <p class="govuk-hint">Not entered</p>
+          {% endif %}
+
+        {% endset %}
+
+        {{ govukSummaryList({
+          rows: [
+            {
+              key: {
+                text: "Organisation name"
+              },
+              value: {
+                text: school.name if school.name else "Not entered",
+                classes: "govuk-hint" if not school.name
+              },
+              actions: {
+                items: [
+                  {
+                    href: actions.change + "/" + "?referrer=check",
+                    text: "Change",
+                    visuallyHiddenText: "name"
+                  }
+                ]
+              }
+            },
+            {
+              key: {
+                text: "UK provider reference number (UKPRN)"
+              },
+              value: {
+                text: school.ukprn if school.ukprn else "Not entered",
+                classes: "govuk-hint" if not school.ukprn
+              }
+            } if school.type != "school",
+            {
+              key: {
+                text: "Unique reference number (URN)"
+              },
+              value: {
+                text: school.urn if school.urn else "Not entered",
+                classes: "govuk-hint" if not school.urn
+              }
+            }
+          ]
+        }) }}
+
+        {% set organisation = school %}
+
+        {% include "_includes/organisations/additional-details.njk" %}
+
+        {% include "_includes/organisations/send-details.njk" %}
+
+        {% include "_includes/organisations/ofsted-details.njk" %}
+
+        {% include "_includes/organisations/contact-details.njk" %}
+
+        {{ govukButton({
+          text: "Add partner school"
+        }) }}
+
+      </form>
+
+      <p class="govuk-body">
+        <a class="govuk-link" href="{{ actions.cancel }}">Cancel</a>
+      </p>
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/support/organisations/partners/schools/delete.njk
+++ b/app/views/support/organisations/partners/schools/delete.njk
@@ -1,0 +1,44 @@
+{% extends "layouts/support.njk" %}
+
+{% set primaryNavId = "organisations" %}
+
+{% set title = "Are you sure you want to remove this partner school?" %}
+{% set caption = school.name + " - " + organisation.name %}
+
+{% block pageTitle %}
+  {{ "Error: " if errors.length }}{{ title + " - " if title }}{{ caption + " - " if caption }}{{ serviceName }} - GOV.UK
+{% endblock %}
+
+{% block beforeContent %}
+{{ govukBackLink({
+  text: "Back",
+  href: actions.back
+}) }}
+{% endblock %}
+
+{% block content %}
+
+  {% include "_includes/error-summary.njk" %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      {% include "_includes/page-heading.njk" %}
+
+      <form action="{{ actions.save }}" method="post" accept-charset="utf-8" novalidate>
+
+        {{ govukButton({
+          text: "Remove partner school",
+          classes: "govuk-button--warning"
+        }) }}
+
+      </form>
+
+      <p class="govuk-body">
+        <a class="govuk-link" href="{{ actions.cancel }}">Cancel</a>
+      </p>
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/support/organisations/partners/schools/find.njk
+++ b/app/views/support/organisations/partners/schools/find.njk
@@ -1,0 +1,75 @@
+{% extends "layouts/support.njk" %}
+
+{% set primaryNavId = "organisations" %}
+
+{% set title = "Enter a school name, URN or postcode" %}
+{% set caption = "Add partner school - " + organisation.name %}
+
+{% block beforeContent %}
+{{ govukBackLink({
+  text: "Back",
+  href: actions.back
+}) }}
+{% endblock %}
+
+{% block content %}
+
+  {% include "_includes/error-summary.njk" %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      {% set headingHtml %}
+        {% include "_includes/page-heading-legend.njk" %}
+      {% endset %}
+
+      <form action="{{ actions.save }}" method="post" accept-charset="utf-8" novalidate>
+
+        <div class="govuk-form-group {{- ' govuk-form-group--error' if (errors | getErrorMessage('school'))}}">
+          {{ govukInput({
+            id: "school",
+            name: "school[name]",
+            label: {
+              html: headingHtml,
+              isPageHeading: true,
+              classes: "govuk-label--l"
+            },
+            value: data.school.name,
+            autocomplete: "off",
+            formGroup: {
+              classes: "govuk-!-margin-bottom-0"
+            },
+            errorMessage: errors | getErrorMessage("school")
+          }) }}
+          <div id="school-autocomplete" class="govuk-body"></div>
+        </div>
+
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+
+      </form>
+
+      <p class="govuk-body">
+        <a class="govuk-link" href="{{ actions.cancel }}">Cancel</a>
+      </p>
+
+    </div>
+  </div>
+
+{% endblock %}
+
+{% block pageScripts %}
+  <script src="/public/javascripts/accessible-autocomplete.min.js"></script>
+  <script src="/public/javascripts/debounce.js"></script>
+  <script src="/public/javascripts/init-autocomplete.js"></script>
+
+  <script type="text/javascript">
+  initAutocomplete({
+    element: "school-autocomplete",
+    input: "school",
+    path: "/school-suggestions",
+    type: "school"
+  });
+  </script>
+{% endblock %}

--- a/app/views/support/organisations/partners/schools/list.njk
+++ b/app/views/support/organisations/partners/schools/list.njk
@@ -1,0 +1,48 @@
+{% extends "layouts/support.njk" %}
+
+{% set primaryNavId = "organisations" %}
+{% set secondaryNavId = "schools" %}
+
+{% set title = organisation.name %}
+
+{% block beforeContent %}
+
+{% endblock %}
+
+{% block content %}
+
+  {% include "_includes/notification-banner.njk" %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% include "_includes/page-heading.njk" %}
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      {% include "../../_secondary-navigation.njk" %}
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h2 class="govuk-heading-m">Partner schools</h2>
+
+      {{ govukButton({
+        text: "Add partner school",
+        href: actions.new
+      }) }}
+
+      {% if partners.length %}
+        {% include "_includes/partners/schools/list.njk" %}
+        {% include "_includes/pagination.njk" %}
+      {% else %}
+        <p class="govuk-body">There are no {{ title | lower }} for {{ organisation.name if organisation.name else "your organisation" }}.</p>
+      {% endif %}
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/support/organisations/partners/schools/show.njk
+++ b/app/views/support/organisations/partners/schools/show.njk
@@ -1,0 +1,43 @@
+{% extends "layouts/support.njk" %}
+
+{% set primaryNavId = "organisations" %}
+
+{% set title = school.name %}
+{% set caption = "Partner schools - " + organisation.name %}
+
+{% block beforeContent %}
+{{ govukBackLink({
+  text: "Back",
+  href: actions.back
+}) }}
+{% endblock %}
+
+{% block content %}
+
+  {% include "_includes/notification-banner.njk" %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      {% include "_includes/page-heading.njk" %}
+
+      {% set organisation = school %}
+
+      {% include "_includes/organisations/details.njk" %}
+
+      {% include "_includes/organisations/additional-details.njk" %}
+
+      {% include "_includes/organisations/send-details.njk" %}
+
+      {% include "_includes/organisations/ofsted-details.njk" %}
+
+      {% include "_includes/organisations/contact-details.njk" %}
+
+      <p class="govuk-body">
+        <a class="govuk-link app-link--destructive" href="{{ actions.delete }}">Remove partner school</a>
+      </p>
+
+    </div>
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
This PR replicates the school and provider partnership flows in Support.

As a support user
I need to add partner providers to schools
So that I can support our school users

As a support user
I need to add partner schools to ITT providers
So that I can support our provider users