### PR TITLE
Add placement without org having mentors

### DIFF
--- a/app/controllers/placements.js
+++ b/app/controllers/placements.js
@@ -339,7 +339,9 @@ exports.placement_details = (req, res) => {
     res.render('../views/placements/schools/show', {
       organisation,
       placement,
-      actions
+      actions: {
+        mentors: `/organisations/${req.params.organisationId}/mentors`
+      }
     })
   }
 }
@@ -465,6 +467,7 @@ exports.new_placement_subject_post = (req, res) => {
   const subjectOptions = subjectHelper.getSubjectOptions({
     subjectLevel: req.session.data.placement.subjectLevel
   })
+  let mentors = mentorModel.findMany({ organisationId: req.params.organisationId })
 
   let back = `/organisations/${req.params.organisationId}/placements/new`
   let save = `/organisations/${req.params.organisationId}/placements/new/subject`
@@ -505,6 +508,8 @@ exports.new_placement_subject_post = (req, res) => {
       },
       errors
     })
+  } else if (!mentors.length) {
+    res.redirect(`/organisations/${req.params.organisationId}/placements/new/check`)
   } else {
     res.redirect(`/organisations/${req.params.organisationId}/placements/new/mentor`)
   }

--- a/app/controllers/placements.js
+++ b/app/controllers/placements.js
@@ -508,10 +508,12 @@ exports.new_placement_subject_post = (req, res) => {
       },
       errors
     })
-  } else if (!mentors.length) {
-    res.redirect(`/organisations/${req.params.organisationId}/placements/new/check`)
-  } else {
-    res.redirect(`/organisations/${req.params.organisationId}/placements/new/mentor`)
+} else {
+    if (!mentors.length) {
+      res.redirect(`/organisations/${req.params.organisationId}/placements/new/check`)
+    } else {
+      res.redirect(`/organisations/${req.params.organisationId}/placements/new/mentor`)
+    }
   }
 }
 

--- a/app/controllers/placements.js
+++ b/app/controllers/placements.js
@@ -467,7 +467,7 @@ exports.new_placement_subject_post = (req, res) => {
   const subjectOptions = subjectHelper.getSubjectOptions({
     subjectLevel: req.session.data.placement.subjectLevel
   })
-  let mentors = mentorModel.findMany({ organisationId: req.params.organisationId })
+  const mentors = mentorModel.findMany({ organisationId: req.params.organisationId })
 
   let back = `/organisations/${req.params.organisationId}/placements/new`
   let save = `/organisations/${req.params.organisationId}/placements/new/subject`

--- a/app/views/_includes/placements/schools/check-your-answers.njk
+++ b/app/views/_includes/placements/schools/check-your-answers.njk
@@ -74,7 +74,7 @@
           }
         ]
       }
-    },
+    } if placement.mentors,
     {
       key: {
         text: "Window"

--- a/app/views/_includes/placements/schools/details.njk
+++ b/app/views/_includes/placements/schools/details.njk
@@ -22,49 +22,92 @@
 {% endif %}
 {% endset %}
 
-{{ govukSummaryList({
-  rows: [
-    {
-      key: {
-        text: "Subject level"
+ {% if placement.mentors %}
+  {{ govukSummaryList({
+    rows: [
+      {
+        key: {
+          text: "Subject level"
+        },
+        value: {
+          text: placement.subjectLevel | getSubjectLevelLabel
+        }
       },
-      value: {
-        text: placement.subjectLevel | getSubjectLevelLabel
+      {
+        key: {
+          text: "Subject"
+        },
+        value: {
+          html: subjectHtml
+        },
+        actions: {
+          items: [
+            {
+              href: actions.change + "/subject",
+              text: "Change",
+              visuallyHiddenText: "subject"
+            }
+          ]
+        }
+      },
+      {
+        key: {
+          text: "Mentor" + ("s" if claim.mentors.length > 1)
+        },
+        value: {
+          html: mentorHtml
+        },
+        actions: {
+          items: [
+            {
+              href: actions.change + "/mentor",
+              text: "Change",
+              visuallyHiddenText: "mentor"
+            }
+          ]
+        }
       }
-    },
-    {
-      key: {
-        text: "Subject"
+    ]
+  }) }}
+
+{% else %}
+
+ {{ govukSummaryList({
+    rows: [
+      {
+        key: {
+          text: "Subject level"
+        },
+        value: {
+          text: placement.subjectLevel | getSubjectLevelLabel
+        }
       },
-      value: {
-        html: subjectHtml
-      },
-      actions: {
-        items: [
-          {
-            href: actions.change + "/subject",
-            text: "Change",
-            visuallyHiddenText: "subject"
-          }
-        ]
+      {
+        key: {
+          text: "Subject"
+        },
+        value: {
+          html: subjectHtml
+        },
+        actions: {
+          items: [
+            {
+              href: actions.change + "/subject",
+              text: "Change",
+              visuallyHiddenText: "subject"
+            }
+          ]
+        }
       }
-    },
-    {
-      key: {
-        text: "Mentor" + ("s" if claim.mentors.length > 1)
-      },
-      value: {
-        html: mentorHtml
-      },
-      actions: {
-        items: [
-          {
-            href: actions.change + "/mentor",
-            text: "Change",
-            visuallyHiddenText: "mentor"
-          }
-        ]
-      }
-    }
-  ]
+    ]
+  }) }}
+
+  {% set insetHtml %}
+    You will need to <a href='{{ actions.mentors }}'>add a mentor</a> to be able to assign mentors to this placement.
+  {% endset %}
+
+  {{ govukInsetText({
+  html: insetHtml
 }) }}
+
+{% endif %}

--- a/app/views/_includes/placements/schools/list.njk
+++ b/app/views/_includes/placements/schools/list.njk
@@ -16,7 +16,7 @@
           </a>
         </td>
         <td class="govuk-table__cell">
-          {% if placement.mentors == "unknown" %}
+          {% if placement.mentors == "unknown" or not placement.mentors %}
             Not known yet
           {% else %}
             <ul class="govuk-list">

--- a/app/views/placements/schools/list.njk
+++ b/app/views/placements/schools/list.njk
@@ -17,22 +17,10 @@
 
       {% include "_includes/page-heading.njk" %}
 
-      {% if not mentors.length %}
-        {% set mentorHtml %}
-          <p class="govuk-body">
-            You need to <a href="{{ actions.mentors }}" class="govuk-link">add a mentor</a> before creating a placement.
-          </p>
-        {% endset %}
-
-        {{ govukInsetText({
-          html: mentorHtml
-        }) }}
-      {% else %}
         {{ govukButton({
           text: "Add placement",
           href: actions.new
         }) }}
-      {% endif %}
 
       {% if placements.length %}
         {% include "_includes/placements/schools/list.njk" %}


### PR DESCRIPTION
MVP version to test, we skip the mentor question if the school has none. When viewing the details page the user sees a message saying they must add a mentor in order to be able to assign the placement.