### PR TITLE
Hide accredited provider ID

### DIFF
--- a/app/views/_includes/organisations/details.njk
+++ b/app/views/_includes/organisations/details.njk
@@ -70,6 +70,6 @@
           }
         ]
       } if 1==0
-    } if organisation.type != "school"
+    } if organisation.type != "school" and 1==0
   ]
 }) }}


### PR DESCRIPTION
Accredited provider ID is only something we use internally and is not known by schools.